### PR TITLE
add AddRazorEmailRenderer for more convenient (and correct) setup

### DIFF
--- a/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
+++ b/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
@@ -1,11 +1,8 @@
-using TRENZ.Lib.RazorMail.Services;
+using TRENZ.Lib.RazorMail.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddMvcCore()
-                .AddRazorViewEngine();
-
-builder.Services.AddTransient<IRazorEmailRenderer, RazorEmailRenderer>();
+builder.Services.AddRazorEmailRenderer();
 
 var app = builder.Build();
 

--- a/TRENZ.Lib.RazorMail/Extensions/RazorMailServiceCollectionExtensions.cs
+++ b/TRENZ.Lib.RazorMail/Extensions/RazorMailServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using TRENZ.Lib.RazorMail.Services;
+
+namespace TRENZ.Lib.RazorMail.Extensions;
+
+public static class RazorMailServiceCollectionExtensions
+{
+    public static IServiceCollection AddRazorEmailRenderer(this IServiceCollection services)
+    {
+        services.AddMvcCore()
+                .AddRazorViewEngine();
+
+        services.AddTransient<IRazorEmailRenderer, RazorEmailRenderer>();
+
+        return services;
+    }
+}


### PR DESCRIPTION
Makes setting up the library easier (you only have to call `builder.Services.AddRazorEmailRenderer();`), and also gives us flexibility to change setup later.