### PR TITLE
wip add README.md to the NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
         <Authors>TRENZ GmbH</Authors>
         <PackageProjectUrl>https://github.com/trenz-gmbh/TRENZ.Lib.RazorMail</PackageProjectUrl>
         <License>MIT</License>
+        <PackageReadmeFile>../README.md</PackageReadmeFile>
         <RepositoryUrl>git@github.com:trenz-gmbh/TRENZ.Lib.RazorMail.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
     </PropertyGroup>

--- a/TRENZ.Lib.RazorMail.Core/TRENZ.Lib.RazorMail.Core.csproj
+++ b/TRENZ.Lib.RazorMail.Core/TRENZ.Lib.RazorMail.Core.csproj
@@ -5,7 +5,7 @@
 
     <RootNamespace>TRENZ.Lib.RazorMail</RootNamespace>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
@@ -13,6 +13,10 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NLog" Version="5.2.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>

--- a/TRENZ.Lib.RazorMail.MailKit/TRENZ.Lib.RazorMail.MailKit.csproj
+++ b/TRENZ.Lib.RazorMail.MailKit/TRENZ.Lib.RazorMail.MailKit.csproj
@@ -12,4 +12,8 @@
       <PackageReference Include="MailKit" Version="4.5.0" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Include="../README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
 </Project>

--- a/TRENZ.Lib.RazorMail.System.Net/TRENZ.Lib.RazorMail.System.Net.csproj
+++ b/TRENZ.Lib.RazorMail.System.Net/TRENZ.Lib.RazorMail.System.Net.csproj
@@ -8,4 +8,8 @@
       <ProjectReference Include="..\TRENZ.Lib.RazorMail.Core\TRENZ.Lib.RazorMail.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Include="../README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Doesn't work yet:

```
/usr/local/share/dotnet/sdk/8.0.203/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5):
error NU5039: The readme file '../README.md' does not exist in the package.
[~/TRENZ/TRENZ.Lib.RazorMail/TRENZ.Lib.RazorMail.System.Net/TRENZ.Lib.RazorMail.System.Net.csproj]
```