### PR TITLE
Improve DX regarding service collection extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
 - Added some badges to the README
+- Marked `AddRazorEmailRenderer` obsolete, use `AddRazorMailRenderer` instead
+- Marked `AddMailKitRazorMailClient` obsolete, use `AddMailKitMailClient` instead
+- Marked `AddSystemNetRazorMailClient` obsolete, use `AddSystemNetMailClient` instead
+- Added `configureClient` parameter to `AddMailKitMailClient` and `AddSystemNetMailClient` so you can configure the
+  client instance (e.g. default headers)
 
 # 2.1.1
 

--- a/TRENZ.Lib.RazorMail.Core/Extensions/RazorMailServiceCollectionExtensions.cs
+++ b/TRENZ.Lib.RazorMail.Core/Extensions/RazorMailServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class RazorMailServiceCollectionExtensions
         services.AddMvcCore()
             .AddRazorViewEngine();
 
-        services.AddTransient<IMailRenderer, MailRenderer>();
+        services.AddTransient<IMailRenderer, RazorMailRenderer>();
 
         return services;
     }

--- a/TRENZ.Lib.RazorMail.Core/Extensions/RazorMailServiceCollectionExtensions.cs
+++ b/TRENZ.Lib.RazorMail.Core/Extensions/RazorMailServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Microsoft.Extensions.DependencyInjection;
 
 using TRENZ.Lib.RazorMail.Interfaces;
@@ -7,10 +9,14 @@ namespace TRENZ.Lib.RazorMail.Extensions;
 
 public static class RazorMailServiceCollectionExtensions
 {
-    public static IServiceCollection AddRazorEmailRenderer(this IServiceCollection services)
+    [Obsolete("Use AddRazorMailRenderer instead.")]
+    public static IServiceCollection AddRazorEmailRenderer(this IServiceCollection services) =>
+        services.AddRazorMailRenderer();
+
+    public static IServiceCollection AddRazorMailRenderer(this IServiceCollection services)
     {
         services.AddMvcCore()
-                .AddRazorViewEngine();
+            .AddRazorViewEngine();
 
         services.AddTransient<IMailRenderer, MailRenderer>();
 

--- a/TRENZ.Lib.RazorMail.Core/Services/BaseSmtpMailClient.cs
+++ b/TRENZ.Lib.RazorMail.Core/Services/BaseSmtpMailClient.cs
@@ -23,7 +23,7 @@ public abstract class BaseSmtpMailClient(IOptions<SmtpAccount> accountOptions) :
     protected SmtpAccount Account => accountOptions.Value;
 
     /// <inheritdoc />
-    public MailHeaderCollection DefaultHeaders { get; } = new();
+    public MailHeaderCollection DefaultHeaders { get; set; } = new();
 
     /// <inheritdoc />
     public Task SendAsync(MailMessage message, CancellationToken cancellationToken = default)

--- a/TRENZ.Lib.RazorMail.Core/Services/RazorMailRenderer.cs
+++ b/TRENZ.Lib.RazorMail.Core/Services/RazorMailRenderer.cs
@@ -26,7 +26,7 @@ namespace TRENZ.Lib.RazorMail.Services;
 /// <summary>
 /// via https://scottsauber.com/2018/07/07/walkthrough-creating-an-html-email-template-with-razor-and-razor-class-libraries-and-rendering-it-from-a-net-standard-class-library/
 /// </summary>
-public class MailRenderer(
+public class RazorMailRenderer(
     [SuppressMessage("ReSharper", "SuggestBaseTypeForParameterInConstructor",
         Justification = "Only IRazorViewEngine is registered in the DI container.")]
     IRazorViewEngine viewEngine,

--- a/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
+++ b/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
@@ -22,5 +22,5 @@ return;
 
 static void ConfigureClient(IServiceProvider sp, IMailClient client)
 {
-    client.DefaultHeaders.ReplyTo = [new MailAddress("noreply@example.com")];
+    client.DefaultHeaders.ReplyTo = [new MailAddress("support@example.com")];
 }

--- a/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
+++ b/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
@@ -6,7 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("appsettings.local.json", optional: true);
 
-builder.Services.AddRazorEmailRenderer();
+builder.Services.AddRazorMailRenderer();
 builder.Services.AddMailKitRazorMailClient("MailKit");
 builder.Services.AddSystemNetRazorMailClient("System.Net.Mail");
 

--- a/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
+++ b/TRENZ.Lib.RazorMail.SampleWebApi/Program.cs
@@ -1,5 +1,7 @@
 using TRENZ.Lib.RazorMail.Extensions;
+using TRENZ.Lib.RazorMail.Interfaces;
 using TRENZ.Lib.RazorMail.MailKit.Extensions;
+using TRENZ.Lib.RazorMail.Models;
 using TRENZ.Lib.RazorMail.SystemNet.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,11 +9,18 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddJsonFile("appsettings.local.json", optional: true);
 
 builder.Services.AddRazorMailRenderer();
-builder.Services.AddMailKitRazorMailClient("MailKit");
-builder.Services.AddSystemNetRazorMailClient("System.Net.Mail");
+builder.Services.AddMailKitMailClient("MailKit", ConfigureClient);
+builder.Services.AddSystemNetMailClient("System.Net.Mail", ConfigureClient);
 
 var app = builder.Build();
 
 app.MapControllers();
 
 app.Run();
+
+return;
+
+static void ConfigureClient(IServiceProvider sp, IMailClient client)
+{
+    client.DefaultHeaders.ReplyTo = [new MailAddress("noreply@example.com")];
+}

--- a/TRENZ.Lib.RazorMail.SampleWebApi/sendsamplemail.http
+++ b/TRENZ.Lib.RazorMail.SampleWebApi/sendsamplemail.http
@@ -1,5 +1,5 @@
 # Via HTTPS and System.Net.Mail
-POST https://localhost:7141/mail/SendWithSystemNet
+POST http://localhost:5102/mail/SendWithSystemNet
 Content-Type: application/json
 
 {


### PR DESCRIPTION
It was quite cumbersome to _set_ the default headers now that they are available. That is because to set them, you need to get ahold of the `IMailClient` instance that will be used to send mails. To do that, you would have to set them somewhere decoupled from the DI container registration (bad because you can' guarantee the code only runs once) or you'd have to create your own instance (basically manually constructing the client instance).

This PR changes that.

You can now pass a callback to the `AddMailKitMailClient` or `AddSystemNetMailClient` extension methods and get full access to the constructed client.

Apart from that I renamed some overloads to better match the services they register (and vice versa). No breaking changes though.